### PR TITLE
fix(frontend/arc-shift): int validation on params 修复Arc偏移参数输入框的整数校验

### DIFF
--- a/frontend/pages/tools/arc-shift.tsx
+++ b/frontend/pages/tools/arc-shift.tsx
@@ -28,11 +28,9 @@ const ToolPage: NextPage = () => {
           arc: Yup.string().required(),
           params: Yup.object().shape({
             x_offset: Yup.number()
-              .integer()
               .transform(emptyStringToUndef)
               .nullable(),
             y_offset: Yup.number()
-              .integer()
               .transform(emptyStringToUndef)
               .nullable(),
           }),
@@ -45,8 +43,8 @@ const ToolPage: NextPage = () => {
 
         <CardWithGrid title="参数">
           <SubtitleTypography>可选参数</SubtitleTypography>
-          <NumberField name="params.x_offset" withTimingCalc />
-          <NumberField name="params.y_offset" withTimingCalc />
+          <NumberField name="params.x_offset" />
+          <NumberField name="params.y_offset" />
         </CardWithGrid>
         <ArcPostProcessCard />
       </ToolFormikForm>


### PR DESCRIPTION
fix(frontend/arc-shift): removed timingcalc on numberfield 删除Arc偏移参数输入框的时间点计算按钮

resolved #39 