### PR TITLE
fix(frontend/input/ImageField): bugs related to clearing image 修复与ImageField清除图片相关的bug

### DIFF
--- a/frontend/components/input.tsx
+++ b/frontend/components/input.tsx
@@ -1,6 +1,6 @@
 import { Trans, useTranslation } from "next-i18next";
 
-import React, { PropsWithChildren, useState } from "react";
+import React, { PropsWithChildren, useRef, useState } from "react";
 import {
   Box,
   Button,
@@ -937,20 +937,16 @@ export const ImageField: React.FC<ImageFieldProps> = ({
   const [field, meta, helpers] = useField(props as { name: any });
   const [preview, setPreview] = React.useState<string | null>(null);
   const { t } = useTranslation("tools");
+  const imgUploadRef = useRef<HTMLInputElement>(null)
 
   let isError = Boolean(meta.touched && meta.error);
   
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     
-    if (!file) {
-      setPreview(null);
-      helpers.setValue(null);
-      return;
-    }
-    
-    // Check if the file is an image (PNG or JPEG)
-    if (!file.type.match('image/png|image/jpeg')) {
+    // when cancel or file type doesn't match
+    if (!file || !file.type.match('image/png|image/jpeg')) {
+      // do nothing
       return;
     }
     
@@ -968,6 +964,9 @@ export const ImageField: React.FC<ImageFieldProps> = ({
   const clearImage = () => {
     setPreview(null);
     helpers.setValue(null);
+    if (imgUploadRef.current) {
+      imgUploadRef.current.value = '';
+    }
     console.log('Image cleared');
   };
   
@@ -981,6 +980,7 @@ export const ImageField: React.FC<ImageFieldProps> = ({
         id={`image-upload-${field.name}`}
         type="file"
         onChange={handleFileChange}
+        ref={imgUploadRef}
       />
       
       <Stack direction="column" spacing={2} alignItems="flex-start">


### PR DESCRIPTION
fix(frontend/input/ImageField): upload problem after clearing the same image 修复了清除图片后无法再上传同一张图片的问题
fix(frontend/input/ImageField): image cleared mistakenly after canceling upload 修复了取消上传后会清除已有图片的问题

fixed #25 